### PR TITLE
Made mapProtectionLimit a public method again

### DIFF
--- a/modules/core/src/main/java/com/griefcraft/modules/limits/LimitsModule.java
+++ b/modules/core/src/main/java/com/griefcraft/modules/limits/LimitsModule.java
@@ -128,7 +128,7 @@ public class LimitsModule extends JavaModule {
      * @param blockId
      * @return
      */
-    private int mapProtectionLimit(Player player, int blockId) {
+    public int mapProtectionLimit(Player player, int blockId) {
         String limit = null;
         Type type = Type.resolve(resolveValue(player, "type"));
 


### PR DESCRIPTION
Our server used this method to integrate with LWC limits. Without this, we have no way of getting a player's limit.
