### PR TITLE
Added WG region blacklist and canBuild check

### DIFF
--- a/skel/worldguard.yml
+++ b/skel/worldguard.yml
@@ -1,10 +1,16 @@
 # WorldGuard LWC module
 # this module can be used to regulate where protections are placed.
 # For example, you can restrict protections to specific regions
-# Using * from one region is the same as setting enabled to false
+# Using '*' as one of the regions limits protections to in any region
+# regionBuild limits protections to regions the player can build in
+# blacklist allows you to override '*' for specific regions
 
 worldguard:
     enabled: false
+    requireBuild: false
     regions:
         - region1
         - region2
+    blacklist:
+        - region3
+        - region4


### PR DESCRIPTION
The blacklist allows you to allow all regions with '*' and then deny specific regions.

The canBuild flag allows you to limit players to only place protections in regions they have build rights to.
