### PR TITLE
Allow showMyNotices to be true when showNotices is false

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -619,11 +619,12 @@ public class LWC {
             protection.save();
         }
 
-        if (configuration.getBoolean("core.showNotices", true) && !Boolean.parseBoolean(resolveProtectionConfiguration(block.getType(), "quiet"))) {
+        if (!Boolean.parseBoolean(resolveProtectionConfiguration(block.getType(), "quiet"))) {
             boolean isOwner = protection.isOwner(player);
+            boolean showNotices = configuration.getBoolean("core.showNotices", true);
             boolean showMyNotices = configuration.getBoolean("core.showMyNotices", true);
 
-            if (!isOwner || (isOwner && showMyNotices)) {
+            if ((!isOwner && showNotices) || (hasAccess && showMyNotices)) {
                 String owner = protection.getOwner();
 
                 // replace your username with "you" if you own the protection


### PR DESCRIPTION
In my experience, if autoRegister, showNotices, and showMyNotices are all off, users often forget whether their own chests are protected and assume they've protected them at some time in the past. Then it surprises them later when it turns out that the chest was simply unprotected, or was protected by someone else and they had just been allowed access to it.

I've had showNotices and showMyNotices both on so that users are reminded of any protections whenever they use their protections, but I've never cared much that they get such a verbose notice when trying to open someone else's protection. I found it odd that when showNotices is off that showMyNotices does nothing.

This commit makes it so that if showNotices is off and showMyNotices is on, then players only ever get the verbose notice if they have access to the protection. All the other combinations of these two options acts just the same as they did before.
