### PR TITLE
Extend the WorldGuard integration module, allowing LWC locks to reference regions

### DIFF
--- a/config/worldguard.yml
+++ b/config/worldguard.yml
@@ -1,6 +1,9 @@
 worldguard:
     enabled: false
 
+    # If true, allow protections to use region-level permissions (i.e., reuse WG region member lists as the block-level ACL)
+    allowRegionPermissions: true
+
     # If true, protections will be allowed in non-regioned areas
     allowProtectionsOutsideRegions: true
 

--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -1629,6 +1629,16 @@ public class LWC {
                 value = value.substring(5);
             }
 
+            if (value.toLowerCase().startsWith("r:")) {
+                type = Permission.Type.REGION;
+                value = value.substring(2);
+            }
+
+            if (value.toLowerCase().startsWith("region:")) {
+                type = Permission.Type.REGION;
+                value = value.substring(7);
+            }
+
             if (value.trim().isEmpty()) {
                 continue;
             }

--- a/src/main/java/com/griefcraft/model/Permission.java
+++ b/src/main/java/com/griefcraft/model/Permission.java
@@ -89,7 +89,12 @@ public class Permission {
         /**
          * Allows a specific item (such as a key) to open the protection when interacted with in hand
          */
-        ITEM;
+        ITEM,
+
+        /**
+         * Applies to members of a WorldGuard region
+         */
+        REGION;
 
         @Override
         public String toString() {


### PR DESCRIPTION
Hi, this is a feature request/patch to improve LWC's integration with WorldGuard, giving LWC block owners/admins the option to tie a chest's lock to a WorldGuard region. This is analogous to the current Towny functionality.
### Example usage:
- `/cmodify region:some_region` - any player accessing the LWC lock is granted access if they have WG build permissions in some_region
- `/cmodify r:some_region` - shorthand for the above
- `/cmodify @r:some_region` - grant admin access to players with WG build permissions
- `/cmodify r:some_other_region:overworld` - reference a region in a different world
- `/cmodify r:#this` - the special "#this" name just looks up the block in WG
### Use case:

Large public SMP server with an emphasis on collaborative projects. WorldGuard regions are used extensively and managed by players. No Towny plugin. LWC is used for all chest protection (on top of 
WorldGuard).

With this setup, project organizers often want to set up a dozen or more shared chests for project building materials. Typically, the builders (i.e., the WG region members) should have access to all chests; other players should not.

Without this patch, there are three basic options that project organizers can use:
1. /cmodify each chest for each member (even with mode persist this can get very tedious for large projects with dozens of builders and dozens of chests)
2. /cpassword each chest (somewhat tedious for builders to access)
3. Leave all the chests public but enclose them in a locked building (also tedious)

This patch adds another option. The chest owner still has to lock each chest in LWC, but it's a one-time thing. New builders added to the WG region will automatically gain access to those chests. It's just the one ACL for the project manager to juggle instead of dozens. Builders accessing the chests don't have to type a command or enter a locked room either.
