### PR TITLE
Implemented two new permissions designed to allow access to a small portion of 'lwc.admin' without endangering the server.

### DIFF
--- a/src/main/java/com/griefcraft/modules/free/FreeModule.java
+++ b/src/main/java/com/griefcraft/modules/free/FreeModule.java
@@ -60,7 +60,7 @@ public class FreeModule extends JavaModule {
         Player player = event.getPlayer();
         event.setResult(Result.CANCEL);
 
-        if (lwc.hasAdminPermission(player, "lwc.admin.remove") || protection.getOwner().equals(player.getName())) {
+        if (lwc.hasAdminPermission(player, "lwc.admin.remove") || protection.getOwner().equals(player.getName()) || lwc.hasPlayerPermission(player, "lwc.remove.other")) {
             LWCProtectionDestroyEvent evt = new LWCProtectionDestroyEvent(player, protection, LWCProtectionDestroyEvent.Method.COMMAND, true, true);
             lwc.getModuleLoader().dispatchEvent(evt);
 

--- a/src/main/java/com/griefcraft/modules/modify/ModifyModule.java
+++ b/src/main/java/com/griefcraft/modules/modify/ModifyModule.java
@@ -67,7 +67,7 @@ public class ModifyModule extends JavaModule {
         LWCPlayer player = lwc.wrapPlayer(event.getPlayer());
         event.setResult(Result.CANCEL);
 
-        if (lwc.canAdminProtection(player.getBukkitPlayer(), protection)) {
+        if (lwc.canAdminProtection(player.getBukkitPlayer(), protection) || lwc.hasPlayerPermission(player.getBukkitPlayer(), "lwc.modify.other")) {
             Action action = player.getAction("modify");
 
             String data = action.getData();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -128,12 +128,16 @@ permissions:
 
   lwc.modify:
       description: Allows you to modify protections you own.
+  lwc.modify.other:
+      description: Allows you to modify protections you don't own.
   lwc.unlock:
       description: Allows you to unlock password-protected protections.
   lwc.info:
       description: Allows you to view the owner and other misc data on a protection.
   lwc.remove:
       description: Allows you to remove protections you own.
+  lwc.remove.other:
+      description: Allows you to remove protections you don't own.
 
   lwc.flag.*:
       description: Gives you access to every usable flag.


### PR DESCRIPTION
Implemented the permissions 'lwc.modify.other' and 'lwc.remove.other'. These permissions add limited access to abilities normally reserved for players with the 'lwc.admin' permission, while preventing them from using specific commands to potentially damage large numbers of protections in a short period of time. This enables low-level staff on servers to use these abilities without posing a potential danger to the server as a whole.
