### PR TITLE
Fix issue 285 /cprivate not working for groups

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -1349,7 +1349,7 @@ public class LWC {
 
         // Permissions init
         permissions = new SuperPermsPermissions();
-
+/* SuperPerms is the recommended interface. Better deal with God rather than with Saints
         if (resolvePlugin("Vault") != null) {
             permissions = new VaultPermissions();
         } else if (resolvePlugin("PermissionsBukkit") != null) {
@@ -1359,7 +1359,7 @@ public class LWC {
         } else if (resolvePlugin("bPermissions") != null) {
             permissions = new bPermissions();
         }
-
+*/
         // Currency init
         currency = new NoCurrency();
 


### PR DESCRIPTION
### Fix several issues with broken implementations of getGroups in permissions plugins integration classes.
#### getGroups returning empty or inconsistant list
##### Test with

```
/lwc debug
```
##### Detail
- Empty groups with Essentials/GroupManager backend and Vault permissions integration class
  - [Issue 285 /cprivate not working for groups](https://github.com/Hidendra/LWC/issues/285)
- Empty groups with PermissionsBukkit backend and Vault permissions integration class
  - [Issue  343 LWC is not finding groups correctly in version 4.21](https://github.com/Hidendra/LWC/issues/343)
- Duplicate or unrelated groups with PermissionsBukkit permissions integration class
