### PR TITLE
Fix LWC getGroups returning empty or inconsistant list while using vault or other permissions wrappers Edit 

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -1349,7 +1349,7 @@ public class LWC {
 
         // Permissions init
         permissions = new SuperPermsPermissions();
-
+/* SuperPerms is the recommended interface. Better deal with God rather than with Saints
         if (resolvePlugin("Vault") != null) {
             permissions = new VaultPermissions();
         } else if (resolvePlugin("PermissionsBukkit") != null) {
@@ -1359,7 +1359,7 @@ public class LWC {
         } else if (resolvePlugin("bPermissions") != null) {
             permissions = new bPermissions();
         }
-
+*/
         // Currency init
         currency = new NoCurrency();
 


### PR DESCRIPTION
getGroups returning empty or inconsistant list
Fix several issues with broken implementations of getGroups:
/lwc debug
- Empty groups with PermissionsBukkit backend and Vault https://github.com/Hidendra/LWC/issues/285
- Duplicate or unrelated groups with PermissionsBukkit
