### PR TITLE
Bukkit for 1.4.4 support

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWCPlugin.java
+++ b/src/main/java/com/griefcraft/lwc/LWCPlugin.java
@@ -368,8 +368,4 @@ public class LWCPlugin extends JavaPlugin {
         return super.getFile();
     }
 
-    @Override
-    public ClassLoader getClassLoader() {
-        return super.getClassLoader();
-    }
 }


### PR DESCRIPTION
Removed overridden getClassLoader() method in com.griefcraft.lwc.LWCPlugin to enable compatibility with bukkit 1.4.4 and up. Tested with bukkit build 2461.
