### PR TITLE
Add ignored WorldGuard regions

### DIFF
--- a/config/worldguard.yml
+++ b/config/worldguard.yml
@@ -17,3 +17,7 @@ worldguard:
     # Regions that LWC protections should NOT be allowed in
     blacklistedRegions:
         - 'Region1'
+
+    # Regions that LWC should ignore while checking permissions
+    ignoredRegions:
+        - 'Region2'

--- a/src/main/java/com/griefcraft/modules/pluginsupport/WorldGuard.java
+++ b/src/main/java/com/griefcraft/modules/pluginsupport/WorldGuard.java
@@ -88,11 +88,11 @@ public class WorldGuard extends JavaModule {
         LWC lwc = event.getLWC();
         CommandSender sender = event.getSender();
         String[] args = event.getArgs();
-        
+
         if (!args[0].equals("purgeregion") && !args[0].equals("protectregion")) {
             return;
         }
-        
+
         // The command name to send to them
         String commandName = args[0];
 
@@ -150,12 +150,12 @@ public class WorldGuard extends JavaModule {
 
         BlockVector minimum = region.getMinimumPoint();
         BlockVector maximum = region.getMaximumPoint();
-        
+
         // Min values
         int minBlockX = minimum.getBlockX();
         int minBlockY = minimum.getBlockY();
         int minBlockZ = minimum.getBlockZ();
-        
+
         // Max values
         int maxBlockX = maximum.getBlockX();
         int maxBlockY = maximum.getBlockY();
@@ -180,7 +180,7 @@ public class WorldGuard extends JavaModule {
 
             // the number of blocks that were registered
             int registered = 0;
-            
+
             for (int x = minBlockX; x <= maxBlockX; x++) {
                 for (int y = minBlockY; y <= maxBlockY; y++) {
                     for (int z = minBlockZ; z <= maxBlockZ; z++) {
@@ -204,7 +204,7 @@ public class WorldGuard extends JavaModule {
                     }
                 }
             }
-            
+
             sender.sendMessage("Registered " + registered + " blocks in the region " + regionName);
             sender.sendMessage("Currently, the owner of these protections is \"" + ownerName + "\". To change this to someone else, run:");
             sender.sendMessage("/lwc admin updateprotections set owner = 'NewOwner' where owner = '" + ownerName + "'");
@@ -327,6 +327,16 @@ public class WorldGuard extends JavaModule {
         // Load the regions the block encompasses
         List<String> regions = regionManager.getApplicableRegionsIDs(vector);
 
+        // Remove all ignored regions
+        if (regions.size() > 0) {
+
+            for (int i = 0; i < regions.size(); i++) {
+                if (isRegionIgnored(regions.get(i))) {
+                    regions.remove(i);
+                }
+            }
+        }
+
         // Are they not in a region, and it's blocked there?
         if (regions.size() == 0) {
             if (!configuration.getBoolean("worldguard.allowProtectionsOutsideRegions", true)) {
@@ -345,6 +355,17 @@ public class WorldGuard extends JavaModule {
                 }
             }
         }
+    }
+
+    /**
+     * Check if a region is ignored
+     *
+     * @param region
+     * @return
+     */
+    private boolean isRegionIgnored(String region) {
+        List<String> ignoredRegions = configuration.getStringList("worldguard.ignoredRegions", new ArrayList<String>());
+        return ignoredRegions.contains("*") || ignoredRegions.contains(region);
     }
 
     /**


### PR DESCRIPTION
I have three cuboids that covers whole map. I want to give users permissions to use LWC in WG regions execpt those three cuboids. There is no way to do this now. Blacklisted regions is not an option because it blocks all the internal regions. That's why I decided to add these ignored regions.
