### PR TITLE
Replaced ugly StackTrace message

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -1418,7 +1418,10 @@ public class LWC {
 
         log("Connecting to " + Database.DefaultType);
         try {
-            physicalDatabase.connect();
+            if (!physicalDatabase.connect()) {
+                Bukkit.getPluginManager().disablePlugin(plugin);
+                return;
+            }
             physicalDatabase.load();
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/griefcraft/sql/Database.java
+++ b/src/main/java/com/griefcraft/sql/Database.java
@@ -251,8 +251,7 @@ public abstract class Database {
             connected = true;
             return true;
         } catch (SQLException e) {
-            log("Failed to connect to " + currentType);
-            e.printStackTrace();
+            log("Failed to connect to " + currentType + ": " + e.getErrorCode() + " - " + e.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
I noticed this horrible stack trace (forgot to start MySQL server) and therefore replaced it. The new one should provide equal/better information.

Additionally I gave the success-return-value a purpose; the plugin is disabled now if false is returned.
