### PR TITLE
Spelling

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -267,12 +267,12 @@ public class LWC {
         String name = StringUtils.replace(material.toString().toLowerCase(), "block", "");
 
         // some name normalizations
-        if (name.contains("sign")) {
+        if (name.contains("Sign")) {
             name = "Sign";
         }
 
-        if (name.contains("furnace")) {
-            name = "furnace";
+        if (name.contains("Furnace")) {
+            name = "Furnace";
         }
 
         if (name.endsWith("_")) {


### PR DESCRIPTION
Made sign the same and made furnace have capitals.

In game its "Sign" and "Furnace" I think this was a bug that wasn't working with something. Someone told me that they think the item had some problem with item handling. This should be the problem I'll be looking through this file for errors.

Cheers
