### PR TITLE
Get more two word item names to display correctly

### DIFF
--- a/core/src/main/resources/lang/lwc_en.properties
+++ b/core/src/main/resources/lang/lwc_en.properties
@@ -25,6 +25,10 @@ sign=Sign
 wooden_door=Wooden Door
 iron_door=Iron Door
 trap_door=Trap Door
+fence_gate=Fence Gate
+brewing_stand=Brewing Stand
+enchantment_table=Enchantment Table
+trapped_chest=Trapped Chest
 
 # Internal LWC error (if this shows up, something went terribly wrong most likely)
 protection.internalerror=%red%[LWC] Internal error. Notify an admin immediately.%white% :%id%


### PR DESCRIPTION
This adds English "localization" to Fence Gates, Brewing Stands, Enchantment Tables, and Trapped Chests making them display in chat without an underscore, fixing #670.

(I apologize for the errors with my previous pull request, a recent update to GitHub required that I change my git email address and the script GitHub support sent me to update the public repo history I found out the hard way only works on repositories where you are the only contributor.)
