### PR TITLE
1.8 spigot update door fix

### DIFF
--- a/core/src/main/java/com/griefcraft/modules/doors/DoorsModule.java
+++ b/core/src/main/java/com/griefcraft/modules/doors/DoorsModule.java
@@ -209,9 +209,10 @@ public class DoorsModule extends JavaModule {
             door.getWorld().playEffect(door.getLocation(), Effect.DOOR_TOGGLE, 0);
 
             // Only change the block above it if it is something we can open or close
+            /* 1.8 fix!
             if (isValid(topHalf.getType())) {
                 topHalf.setData((byte) (topHalf.getData() ^ 0x4));
-            }
+            }*/
         }
     }
 


### PR DESCRIPTION
There was a problem with 1.8 spigot protocol update. Doors sudenly starts to break (especialy doubledoors) more at http://www.spigotmc.org/threads/1-8-protocol-doors-glitching.28572/#post-330072 

With Thinkofdeath's help there is a fix. It looks that it works on older versions of bukkit/spigot too
