### PR TITLE
Proposal: Add trapped chest support to droptransfer targets

### DIFF
--- a/core/src/main/java/com/griefcraft/modules/modes/DropTransferModule.java
+++ b/core/src/main/java/com/griefcraft/modules/modes/DropTransferModule.java
@@ -195,7 +195,8 @@ public class DropTransferModule extends JavaModule {
         if (!canAccess) {
             lwc.sendLocale(player, "protection.interact.dropxfer.noaccess");
         } else {
-            if (protection.getBlockId() != Material.CHEST.getId()) {
+            int blockId = protection.getBlockId();
+            if (blockId != Material.CHEST.getId() && blockId != Material.TRAPPED_CHEST.getId()) {
                 lwc.sendLocale(player, "protection.interact.dropxfer.notchest");
                 player.removeAllActions();
                 event.setResult(Result.CANCEL);


### PR DESCRIPTION
*This change has been untested for compilation errors or bugs.*

This allows players to select and use trapped chests as a target for the droptransfer mode.