### PR TITLE
Duplicate subexpressions in LWC.java

### DIFF
--- a/core/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/core/src/main/java/com/griefcraft/lwc/LWC.java
@@ -864,7 +864,7 @@ public class LWC {
             int plrZ = location.getBlockZ();
 
             // simple check of the ranges
-            if (plrX >= minX && plrX <= maxX && plrY >= plrY && plrY <= maxY && plrZ >= minZ && plrZ <= maxZ) {
+            if (plrX >= minX && plrX <= maxX && plrY >= minY && plrY <= maxY && plrZ >= minZ && plrZ <= maxZ) {
                 return player;
             }
         }


### PR DESCRIPTION
`plrY >= plrY` repeats `plrY`. Looks like this should be `plrY >= minY`
