### PR TITLE
API: Add event when magnet flag is sucking up an item

### DIFF
--- a/core/src/main/java/com/griefcraft/modules/flag/MagnetModule.java
+++ b/core/src/main/java/com/griefcraft/modules/flag/MagnetModule.java
@@ -32,6 +32,7 @@ import com.griefcraft.lwc.LWC;
 import com.griefcraft.model.Flag;
 import com.griefcraft.model.Protection;
 import com.griefcraft.scripting.JavaModule;
+import com.griefcraft.scripting.event.LWCMagnetPullEvent;
 import com.griefcraft.util.config.Configuration;
 import com.narrowtux.showcase.Showcase;
 import org.bukkit.Bukkit;
@@ -123,6 +124,14 @@ public class MagnetModule extends JavaModule {
                         if (item.getPickupDelay() > item.getTicksLived()) {
                             continue; // a player wouldn't have had a chance to pick it up yet
                         }
+						
+						LWCMagnetPullEvent event = new LWCMagnetPullEvent(item);
+						lwc.getModuleLoader().dispatchEvent(event);
+						
+						// has the event been cancelled?
+						if (event.isCancelled()) {
+							continue;
+						}
 
                         Location location = item.getLocation();
                         int x = location.getBlockX();

--- a/core/src/main/java/com/griefcraft/modules/flag/MagnetModule.java
+++ b/core/src/main/java/com/griefcraft/modules/flag/MagnetModule.java
@@ -124,14 +124,14 @@ public class MagnetModule extends JavaModule {
                         if (item.getPickupDelay() > item.getTicksLived()) {
                             continue; // a player wouldn't have had a chance to pick it up yet
                         }
-						
-						LWCMagnetPullEvent event = new LWCMagnetPullEvent(item);
-						lwc.getModuleLoader().dispatchEvent(event);
-						
-						// has the event been cancelled?
-						if (event.isCancelled()) {
-							continue;
-						}
+			
+                        LWCMagnetPullEvent event = new LWCMagnetPullEvent(item);
+                        lwc.getModuleLoader().dispatchEvent(event);
+
+                        // has the event been cancelled?
+                        if (event.isCancelled()) {
+                            continue;
+                        }
 
                         Location location = item.getLocation();
                         int x = location.getBlockX();

--- a/core/src/main/java/com/griefcraft/scripting/JavaModule.java
+++ b/core/src/main/java/com/griefcraft/scripting/JavaModule.java
@@ -33,6 +33,7 @@ import com.griefcraft.scripting.event.LWCAccessEvent;
 import com.griefcraft.scripting.event.LWCBlockInteractEvent;
 import com.griefcraft.scripting.event.LWCCommandEvent;
 import com.griefcraft.scripting.event.LWCDropItemEvent;
+import com.griefcraft.scripting.event.LWCMagnetPullEvent;
 import com.griefcraft.scripting.event.LWCProtectionDestroyEvent;
 import com.griefcraft.scripting.event.LWCProtectionInteractEvent;
 import com.griefcraft.scripting.event.LWCProtectionRegisterEvent;
@@ -109,5 +110,9 @@ public class JavaModule implements Module {
     public void onSendLocale(LWCSendLocaleEvent event) {
 
     }
+
+	public void onMagnetPull(LWCMagnetPullEvent event) {
+		
+	}
 
 }

--- a/core/src/main/java/com/griefcraft/scripting/Module.java
+++ b/core/src/main/java/com/griefcraft/scripting/Module.java
@@ -33,6 +33,7 @@ import com.griefcraft.scripting.event.LWCAccessEvent;
 import com.griefcraft.scripting.event.LWCBlockInteractEvent;
 import com.griefcraft.scripting.event.LWCCommandEvent;
 import com.griefcraft.scripting.event.LWCDropItemEvent;
+import com.griefcraft.scripting.event.LWCMagnetPullEvent;
 import com.griefcraft.scripting.event.LWCProtectionDestroyEvent;
 import com.griefcraft.scripting.event.LWCProtectionInteractEvent;
 import com.griefcraft.scripting.event.LWCProtectionRegisterEvent;
@@ -138,5 +139,12 @@ public interface Module {
      * @param event
      */
     public void onSendLocale(LWCSendLocaleEvent event);
+    
+    /**
+     * Called when the Magnet (flag) pulls an item
+     * 
+     * @param event
+     */
+    public void onMagnetPull(LWCMagnetPullEvent event);
 
 }

--- a/core/src/main/java/com/griefcraft/scripting/ModuleLoader.java
+++ b/core/src/main/java/com/griefcraft/scripting/ModuleLoader.java
@@ -36,6 +36,7 @@ import com.griefcraft.scripting.event.LWCBlockInteractEvent;
 import com.griefcraft.scripting.event.LWCCommandEvent;
 import com.griefcraft.scripting.event.LWCDropItemEvent;
 import com.griefcraft.scripting.event.LWCEvent;
+import com.griefcraft.scripting.event.LWCMagnetPullEvent;
 import com.griefcraft.scripting.event.LWCProtectionDestroyEvent;
 import com.griefcraft.scripting.event.LWCProtectionInteractEvent;
 import com.griefcraft.scripting.event.LWCProtectionRegisterEvent;
@@ -134,7 +135,12 @@ public class ModuleLoader {
         /**
          * Called when LWC's config is reloaded
          */
-        RELOAD_EVENT;
+        RELOAD_EVENT,
+        
+        /**
+         * Called when the Magnet (flag) pulls an item
+         */
+        MAGNET_PULL(1);
 
         Event() {
         }
@@ -259,6 +265,8 @@ public class ModuleLoader {
                     event = Event.REDSTONE;
                 } else if (parameter == LWCReloadEvent.class) {
                     event = Event.RELOAD_EVENT;
+                } else if (parameter == LWCMagnetPullEvent.class) {
+                	event = Event.MAGNET_PULL;
                 }
 
                 // ok!
@@ -352,6 +360,8 @@ public class ModuleLoader {
                     module.onRedstone((LWCRedstoneEvent) event);
                 } else if (type == Event.RELOAD_EVENT) {
                     module.onReload((LWCReloadEvent) event);
+                } else if (type == Event.MAGNET_PULL) {
+                	module.onMagnetPull((LWCMagnetPullEvent) event);
                 }
             }
         } catch (Throwable throwable) {

--- a/core/src/main/java/com/griefcraft/scripting/event/LWCMagnetPullEvent.java
+++ b/core/src/main/java/com/griefcraft/scripting/event/LWCMagnetPullEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2011 Tyler Blair. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and contributors and should not be interpreted as representing official policies,
+ * either expressed or implied, of anybody else.
+ */
+
+package com.griefcraft.scripting.event;
+
+import org.bukkit.entity.Item;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import com.griefcraft.scripting.ModuleLoader;
+
+public class LWCMagnetPullEvent extends LWCEvent implements Cancellable {
+	
+	private static final HandlerList handlers = new HandlerList();
+	private Item item;
+    private boolean cancelled;
+
+    public LWCMagnetPullEvent(Item item) {
+    	super(ModuleLoader.Event.MAGNET_PULL);
+    	
+        this.item = item;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+}


### PR DESCRIPTION
This event is firing everytime the magnet flag/module is pulling an item into a chest.

I would need that as an API call for my resource, because it has a floating item (similar to Showcase) above a chest which is currently always being pulled into the chest that is not what it's supposed to do.

Probably other developers would need that too.

_Sorry for any language mistakes_
